### PR TITLE
Remove reference to typed hole feature in test comment

### DIFF
--- a/tasty/data/error/type/forall-exists-input.ffg
+++ b/tasty/data/error/type/forall-exists-input.ffg
@@ -1,13 +1,6 @@
 # This test illustrates that existentially quantified field variables (like `a`)
 # will not unify with other variables outside of the scope of the existential
 # quantification.
-#
-# However, you can use a typed hole instead of the existential quantification,
-# and the reason the typed hole works is that it is anonymous, so there is no
-# need to worry about the named type variable being referenced out of scope.
-#
-# See `./tasty/data/complex/forall-hole-input.ffg` for an example of this
-# working with a typed hole
 let values
       : List (exists (a : Type) . a)
       =  [ 2, true ]


### PR DESCRIPTION
This feature no longer exists