### PR TITLE
Improve inference for a record as a subtype of JSON

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -358,6 +358,14 @@ subtype subType₀ superType₀ = do
 
                 subtype type_ (Context.solveType context superType₀)
 
+        (Type.Record{ fields = Type.Fields fieldTypes (Monotype.UnsolvedFields existential) }, Type.Scalar{ scalar = Monotype.JSON }) -> do
+            instantiateFieldsL existential (Type.location superType₀) (Type.Fields [] Monotype.EmptyFields)
+
+            for_ fieldTypes \(_, type_) -> do
+                context <- get
+
+                subtype type_ (Context.solveType context superType₀)
+
         (Type.Record{ fields = Type.Fields subFieldTypesList subRemainingFields }, Type.Record{ fields = Type.Fields superFieldTypesList superRemainingFields }) -> do
             let subFieldTypes   = Map.fromList subFieldTypesList
             let superFieldTypes = Map.fromList superFieldTypesList


### PR DESCRIPTION
The motivation for this change is so that something like this works:

```haskell
(http (GET{ url: "https://httpbin.org/get" })).headers
```

Before this change that would fail because `{ headers: JSON, a? }` is not a subtype of `JSON`.  This change fixes that by adding a subtyping rule to handle that case (defaulting `a?` to the empty set of fields).