### PR TITLE
Fix bug in defaulted record fields

### DIFF
--- a/src/Grace/Normalize.hs
+++ b/src/Grace/Normalize.hs
@@ -547,11 +547,20 @@ apply keyToMethods function₀ argument₀ = runConcurrently (loop function₀ a
         extraEnv = do
             (fieldName, assignment) <- fieldNames
 
-            let value = case HashMap.lookup fieldName keyValues of
-                    Just n  -> n
-                    Nothing -> case assignment of
-                        Just a  -> Value.Application (Value.Builtin Some) a
+            let value = case assignment of
+                    Nothing -> case HashMap.lookup fieldName keyValues of
+                        Just n -> n
                         Nothing -> Value.Scalar Null
+                    Just a -> case HashMap.lookup fieldName keyValues of
+                        Just (Value.Application (Value.Builtin Some) n) ->
+                            n
+                        Just (Value.Scalar Null) ->
+                            a
+                        Nothing ->
+                            a
+                        -- This case should only be hit if elaboration fails
+                        Just n ->
+                            n
 
             return (fieldName, value)
     loop

--- a/tasty/data/complex/interpolate-default-input.ffg
+++ b/tasty/data/complex/interpolate-default-input.ffg
@@ -1,0 +1,6 @@
+let greet{ name = "John Doe" } = "Hello, ${name}!"
+
+in  [ greet{ name: "Mary Sue" }
+    , greet{ name: null }
+    , greet{  }
+    ]

--- a/tasty/data/complex/interpolate-default-output.ffg
+++ b/tasty/data/complex/interpolate-default-output.ffg
@@ -1,0 +1,1 @@
+[ "Hello, Mary Sue!", "Hello, John Doe!", "Hello, John Doe!" ]

--- a/tasty/data/complex/interpolate-default-type.ffg
+++ b/tasty/data/complex/interpolate-default-type.ffg
@@ -1,0 +1,1 @@
+List Text


### PR DESCRIPTION
Previously defaulted record fields would be incorrectly defaulted to include an (undesirable) `some` wrapper.  For example, in an expression like this:

```haskell
let greet{ name = "John Doe" } = "Hello, ${name}!"

in  greet{ name: "Mary Sue" }
```

… that would fail because the type of `greet` would be (correctly) inferred to be:

```haskell
greet : { name : Optional Text } -> Text
```

… and then when checking `greet`'s argument (`{ name: "Mary Sue" }`) against that type, the argument would be elaborated to:

```haskell
{ name: some "Mary Sue" }
```

… and then during evaluation the `some` would be included in the evaluation environment, causing it to be interpolated like this:

```haskell
"Hello, ${some "Mary Sue"}"
```

… causing it to fail.  The correct thing to do is to strip the `some` before adding the argument to the evaluation environment.

Another issue is that defaulting in this way would fail if the user provided an explicit `null`, like this:
    
```haskell
let greet{ name = "John Doe" } = "Hello, ${name}!"

in  greet{ name: null }
```
    
… even though that should be valid (the same as `greet{ }`).
