### PR TITLE
trygrace.dev: Render markdown as HTML

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,10 @@
                                 pkgsNew.haskell.lib.dontCheck
                                   haskellPackagesOld.bsb-http-chunked;
 
+                              commonmark =
+                                pkgsNew.haskell.lib.dontCheck
+                                  haskellPackagesOld.commonmark;
+
                               conduit =
                                 pkgsNew.haskell.lib.dontCheck
                                   haskellPackagesOld.conduit;

--- a/grace.cabal
+++ b/grace.cabal
@@ -131,8 +131,9 @@ executable try-grace
   build-depends:       base
                      , aeson
                      , async
-                     , ghcjs-base
+                     , commonmark
                      , containers
+                     , ghcjs-base
                      , grace
                      , insert-ordered-containers
                      , lens
@@ -146,7 +147,7 @@ executable try-grace
 
   hs-source-dirs:      try-grace
 
-  ghc-options:         -Wall
+  ghc-options:         -Wall +RTS -K0 -RTS
 
   default-language:    Haskell2010
   if !(impl(ghcjs) || os(ghcjs))


### PR DESCRIPTION
`Text` outputs will now be treated as markdown and converted to HTML