### PR TITLE
Fix Garnix server deploy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -251,7 +251,11 @@
                     };
                   };
 
-                  nixpkgs.overlays = [ self.overlays.ghcjs ];
+                  nixpkgs = {
+                    config.allowBroken = true;
+
+                    overlays = [ self.overlays.ghcjs ];
+                  };
 
                   security = {
                     acme = {

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -12,6 +12,7 @@ builds:
  - apps.aarch64-darwin.default
  - apps.x86_64-linux.default
  - apps.aarch64-linux.default
+ - nixosConfigurations.default
 servers:
 - configuration: default
   deployment:


### PR DESCRIPTION
Apparently the server needs to be built by garnix.yaml (either explicitly or implicitly)