### PR TITLE
Enable "zen mode"

### DIFF
--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -1587,13 +1587,43 @@ main = do
 
     codeInput  <- setupCodemirrorInput inputArea
 
-    focus codeInput
-
     counter <- IORef.newIORef 0
 
     params <- getSearchParams
 
     hasTutorial <- hasParam params "tutorial"
+
+    hasExpression <- hasParam params "expression"
+
+    hasEdit <- hasParam params "edit"
+
+    edit <- if hasTutorial
+        then do
+            setParam params "edit" "true"
+
+            return True
+        else do
+            if hasEdit
+                then do
+                    return True
+                else do
+                    if hasExpression
+                        then do
+                            return False
+                        else do
+                            setParam params "edit" "true"
+
+                            return True
+
+    if edit
+        then do
+            title <- getElementById "title"
+
+            setDisplay title "block"
+
+            focus codeInput
+        else do
+            setDisplay (getWrapperElement codeInput) "none"
 
     tutorialRef <- IORef.newIORef hasTutorial
 
@@ -1601,7 +1631,7 @@ main = do
 
     output <- getElementById "output"
 
-    (setBusy, setSuccess, setError) <- createForm True output
+    (setBusy, setSuccess, setError) <- createForm edit output
 
     let interpret () = do
             text <- getValue codeInput
@@ -1782,8 +1812,6 @@ main = do
     addEventListener startTutorial "click" startTutorialCallback
 
     Monad.when hasTutorial enableTutorial
-
-    hasExpression <- hasParam params "expression"
 
     Monad.when hasExpression do
         expression <- getParam params "expression"

--- a/website/index.html
+++ b/website/index.html
@@ -15,13 +15,12 @@
 <body>
 <div class="container">
 <header>
-<h1 class="display-4">Grace browser</h1>
+<h1 id="title" style="display: none;" class="display-4">Grace browser</h1>
 </header>
 <main>
 <textarea style="display: none;" id="input"></textarea>
 <br/>
 <button id="start-tutorial" type="button" class="btn btn-primary" style="display: none;">Try the tutorial</button>
-<br/>
 <div id="output"></div>
 <div id="codemirror-buffer"></div>
 </main>


### PR DESCRIPTION
You can now share just the form (without the editor) by removing the `edit=true` query parameter.